### PR TITLE
build: Fix library getting checked for changes twice

### DIFF
--- a/build/build.mk
+++ b/build/build.mk
@@ -107,11 +107,11 @@ $(NAME_READY) && $(LIBS_READY)
 endef
 
 define NAME_READY
-$(MAKE) --question $(NAME) && $(LIBS_READY)
+$(MAKE) --question $(NAME) &>/dev/null
 endef
 
 define LIBS_READY
-$(foreach lib,$(LIBRARIES),$(MAKE) --question --directory=$(lib) && ) true
+$(foreach lib,$(LIBRARIES),$(MAKE) --question --directory=$(lib) &>/dev/null && ) true
 endef
 
 ifeq (4.4, $(firstword $(sort $(MAKE_VERSION) 4.4)))

--- a/build/build.mk
+++ b/build/build.mk
@@ -169,6 +169,10 @@ CXXFLAGS		:=	$(CXXFLAGS_STD) $(CXXFLAGS_OPT)
 RECOMPILE		:=	true
 endif
 
+ifeq (re, $(filter re,$(MAKECMDGOALS) $(MODE)))
+RECOMPILE		:=	true
+endif
+
 ifeq (run, $(filter run,$(MAKECMDGOALS) $(MODE)))
 RUN				:=	true
 endif

--- a/build/print.mk
+++ b/build/print.mk
@@ -72,11 +72,7 @@ MSG_COMP_INFO	:=	$(STY_ITA)$(STY_WHI)"Compiler version: $(CC_VERSION)"$(STY_RES)
 
 MSG_HELP		:=	$(STY_ITA)$(STY_WHI)"Run 'make help' to see all available Makefile targets."$(STY_RES)
 
-ifneq (, $(filter $(REBUILD_TARGETS),$(MAKECMDGOALS) $(MODE)))
-MSG_START		:=	$(STY_ITA)"Rebuilding $(NAME) ... "$(STY_RES)
-else
-MSG_START		:=	$(STY_ITA)"Building $(NAME) ... "$(STY_RES)
-endif
+MSG_START		=	$(STY_ITA)$(if $(RECOMPILE),"Rebuilding","Building")" $(NAME) ... "$(STY_RES)
 
 MSG_SUCCESS		?=	$(STY_BOL)$(STY_ITA)$($(COLOR_MAKE))"DONE!"$(STY_RES)
 


### PR DESCRIPTION
This will make the compilation a bit faster.

Also:
- **Ensure no erroneous printouts from the Makefile**
  I had some in my CPP module when only recompiling the library.
- **Support `re` in `MODE`**
  Can be used like `make val MODE=re`.
- **Fix recompilation message not showing correctly**
  `make re` still printed "Building" instead of "Rebuilding".